### PR TITLE
feat: Implementa módulo de anunciantes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,8 @@
         "psr-4": {
             "App\\": "src/"
         }
-    }    
+    },
+    "require": {
+        "ramsey/uuid": "^4.8"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,224 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d751713988987e9331980363e24189ce",
-    "packages": [],
+    "content-hash": "ed6d76d0aed675a366c50abd8c8d76de",
+    "packages": [
+        {
+            "name": "brick/math",
+            "version": "0.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/fc7ed316430118cc7836bf45faff18d5dfc8de04",
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^10.1",
+                "vimeo/psalm": "6.8.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "bignumber",
+                "brick",
+                "decimal",
+                "integer",
+                "math",
+                "mathematics",
+                "rational"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/0.13.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-29T13:50:30+00:00"
+        },
+        {
+            "name": "ramsey/collection",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/collection.git",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "captainhook/plugin-composer": "^5.3",
+                "ergebnis/composer-normalize": "^2.45",
+                "fakerphp/faker": "^1.24",
+                "hamcrest/hamcrest-php": "^2.0",
+                "jangregor/phpstan-prophecy": "^2.1",
+                "mockery/mockery": "^1.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpspec/prophecy-phpunit": "^2.3",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "ramsey/coding-standard": "^2.3",
+                "ramsey/conventional-commits": "^1.6",
+                "roave/security-advisories": "dev-latest"
+            },
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "force-install": true
+                },
+                "ramsey/conventional-commits": {
+                    "configFile": "conventional-commits.json"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Collection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "A PHP library for representing and manipulating collections.",
+            "keywords": [
+                "array",
+                "collection",
+                "hash",
+                "map",
+                "queue",
+                "set"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/collection/issues",
+                "source": "https://github.com/ramsey/collection/tree/2.1.1"
+            },
+            "time": "2025-03-22T05:38:12+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "4.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
+                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13",
+                "ext-json": "*",
+                "php": "^8.0",
+                "ramsey/collection": "^1.2 || ^2.0"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "captainhook/captainhook": "^5.25",
+                "captainhook/plugin-composer": "^5.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "ergebnis/composer-normalize": "^2.47",
+                "mockery/mockery": "^1.6",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock": "^2.6",
+                "php-mock/php-mock-mockery": "^1.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpbench/phpbench": "^1.2.14",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "slevomat/coding-standard": "^8.18",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "suggest": {
+                "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
+                "ext-gmp": "Enables faster math with arbitrary-precision integers using GMP.",
+                "ext-uuid": "Enables the use of PeclUuidTimeGenerator and PeclUuidRandomGenerator.",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "force-install": true
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP library for generating and working with universally unique identifiers (UUIDs).",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "support": {
+                "issues": "https://github.com/ramsey/uuid/issues",
+                "source": "https://github.com/ramsey/uuid/tree/4.8.1"
+            },
+            "time": "2025-06-01T06:28:46+00:00"
+        }
+    ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",

--- a/public/index.php
+++ b/public/index.php
@@ -22,6 +22,7 @@ $routes = [
     ... routes('auth'),
     ... routes('advertisement'),
     ... routes('category'),
+    ... routes('advertiser'),
 ];
 
 // CRUD Advertisement

--- a/routes/advertiserRoutes.php
+++ b/routes/advertiserRoutes.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Controller\AdvertiserController;
+
+return [
+    '/anunciantes' => [AdvertiserController::class, 'index'],
+    '/anunciantes/novo' => [AdvertiserController::class, 'create'],
+    '/anunciantes/cadastrar' => [AdvertiserController::class, 'store'],
+    '/anunciantes/editar' => [AdvertiserController::class, 'edit'],
+    '/anunciantes/atualizar' => [AdvertiserController::class, 'update'],
+    '/anunciantes/ativar' => [AdvertiserController::class, 'activate'],
+    '/anunciantes/desativar' => [AdvertiserController::class, 'deactivate'],
+    '/anunciantes/deletar' => [AdvertiserController::class, 'delete'],
+]; 

--- a/routes/userRoutes.php
+++ b/routes/userRoutes.php
@@ -6,5 +6,4 @@ return [
     '/usuarios' => [UserController::class, 'list'],
     '/usuarios/adicionar' => [UserController::class, 'add'],
     '/usuario/perfil' => [UserController::class, 'profile'],
-    '/anunciantes' => [UserController::class, 'list'],
 ];

--- a/src/Controller/AdvertiserController.php
+++ b/src/Controller/AdvertiserController.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+final class AdvertiserController extends AbstractController
+{
+    public const string VIEW_INDEX = 'advertiser/index';
+    public const string VIEW_CREATE = 'advertiser/create';
+    public const string VIEW_EDIT = 'advertiser/edit';
+
+    public function index(): void
+    {
+        $advertisers = [
+            [
+                'name' => 'João Silva',
+                'email' => 'joao@email.com',
+                'document' => '123.456.789-00',
+                'phone' => '(85) 99999-9999',
+                'status' => 'ativo'
+            ],
+            [
+                'name' => 'Maria Santos',
+                'email' => 'maria@email.com',
+                'document' => '987.654.321-00',
+                'phone' => '(85) 88888-8888',
+                'status' => 'inativo'
+            ]
+        ];
+        
+        $this->render(self::VIEW_INDEX, [
+            'advertisers' => $advertisers
+        ]);
+    }
+
+    public function create(): void
+    {
+        $this->render(self::VIEW_CREATE);
+    }
+
+    public function store(): void
+    {
+        header('Location: /anunciantes');
+        exit;
+    }
+
+    public function edit(): void
+    {
+        $advertiser = [
+            'name' => 'João Silva',
+            'email' => 'joao@email.com',
+            'document' => '123.456.789-00',
+            'phone' => '(85) 99999-9999',
+            'status' => 'ativo'
+        ];
+        
+        $this->render(self::VIEW_EDIT, [
+            'advertiser' => $advertiser
+        ]);
+    }
+
+    public function update(): void
+    {
+        header('Location: /anunciantes');
+        exit;
+    }
+
+    public function activate(): void
+    {
+        header('Location: /anunciantes');
+        exit;
+    }
+
+    public function deactivate(): void
+    {
+        header('Location: /anunciantes');
+        exit;
+    }
+
+    public function delete(): void
+    {
+        header('Location: /anunciantes');
+        exit;
+    }
+} 

--- a/src/Enum/Status.php
+++ b/src/Enum/Status.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum Status: string
+{
+    case ACTIVE = 'ACTIVE';
+    case INACTIVE = 'INACTIVE';
+} 

--- a/src/Model/Advertiser.php
+++ b/src/Model/Advertiser.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model;
+
+use App\Enum\Status;
+use DateTime;
+use Ramsey\Uuid\Uuid;
+
+class Advertiser
+{
+    private string $id;
+    private string $name;
+    private string $email;
+    private string $document;
+    private string $phone;
+    private Status $status;
+    private DateTime $createdAt;
+    private DateTime $updatedAt;
+
+    public function __construct(
+        string $name,
+        string $email,
+        string $document,
+        string $phone
+    ) {
+        $this->id = Uuid::uuid4()->toString();
+        $this->name = $name;
+        $this->email = $email;
+        $this->document = $document;
+        $this->phone = $phone;
+        $this->status = Status::INACTIVE; // Valor padrão INACTIVE
+        $this->createdAt = new DateTime();
+        $this->updatedAt = new DateTime();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+        $this->updateTimestamps();
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+        $this->updateTimestamps();
+    }
+
+    public function getDocument(): string
+    {
+        return $this->document;
+    }
+
+    public function setDocument(string $document): void
+    {
+        $this->document = $document;
+        $this->updateTimestamps();
+    }
+
+    public function getPhone(): string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(string $phone): void
+    {
+        $this->phone = $phone;
+        $this->updateTimestamps();
+    }
+
+    public function getStatus(): Status
+    {
+        return $this->status;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === Status::ACTIVE;
+    }
+
+    public function activate(): void
+    {
+        $this->status = Status::ACTIVE;
+        $this->updateTimestamps();
+    }
+
+    public function deactivate(): void
+    {
+        $this->status = Status::INACTIVE;
+        $this->updateTimestamps();
+    }
+
+    public function getCreatedAt(): DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    private function updateTimestamps(): void
+    {
+        $this->updatedAt = new DateTime();
+    }
+} 

--- a/views/advertiser/create.phtml
+++ b/views/advertiser/create.phtml
@@ -1,0 +1,39 @@
+<section class="container mt-5">
+    <div class="row">
+        <div class="col-md-8 offset-md-2">
+            <div class="card">
+                <div class="card-header bg-dark text-white">
+                    <h4>Cadastro de Anunciante</h4>
+                </div>
+                <div class="card-body">
+                    <form action="/anunciantes/cadastrar" method="POST">
+                        <div class="mb-3">
+                            <label for="name" class="form-label">Nome Completo *</label>
+                            <input type="text" class="form-control" id="name" name="name" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="email" class="form-label">E-mail *</label>
+                            <input type="email" class="form-control" id="email" name="email" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="document" class="form-label">CPF/CNPJ *</label>
+                            <input type="text" class="form-control" id="document" name="document" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="phone" class="form-label">Telefone *</label>
+                            <input type="tel" class="form-control" id="phone" name="phone" required>
+                        </div>
+
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">Cadastrar</button>
+                            <a href="/anunciantes" class="btn btn-secondary">Voltar</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</section> 

--- a/views/advertiser/edit.phtml
+++ b/views/advertiser/edit.phtml
@@ -1,0 +1,43 @@
+<div class="container mt-5">
+    <div class="row">
+        <div class="col-md-8 offset-md-2">
+            <div class="card">
+                <div class="card-header">
+                    <h4>Editar Anunciante</h4>
+                </div>
+                <div class="card-body">
+                    <form action="/anunciantes/atualizar" method="POST">
+                        <div class="mb-3">
+                            <label for="name" class="form-label">Nome Completo *</label>
+                            <input type="text" class="form-control" id="name" name="name" 
+                                value="<?= $advertiser['name'] ?>" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="email" class="form-label">E-mail *</label>
+                            <input type="email" class="form-control" id="email" name="email" 
+                                value="<?= $advertiser['email'] ?>" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="document" class="form-label">CPF/CNPJ *</label>
+                            <input type="text" class="form-control" id="document" name="document" 
+                                value="<?= $advertiser['document'] ?>" required>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="phone" class="form-label">Telefone *</label>
+                            <input type="tel" class="form-control" id="phone" name="phone" 
+                                value="<?= $advertiser['phone'] ?>" required>
+                        </div>
+
+                        <div class="d-grid gap-2">
+                            <button type="submit" class="btn btn-primary">Atualizar</button>
+                            <a href="/anunciantes" class="btn btn-secondary">Voltar</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div> 

--- a/views/advertiser/index.phtml
+++ b/views/advertiser/index.phtml
@@ -1,0 +1,56 @@
+<section class="card card-body mt-5">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2>Anunciantes</h2>
+        <a href="/anunciantes/novo" class="btn btn-primary">Novo Anunciante</a>
+    </div>
+
+    <div class="card-body">
+        <table class="table">
+            <thead class="table-dark">
+                <tr>
+                    <th>Nome</th>
+                    <th>E-mail</th>
+                    <th>Documento</th>
+                    <th>Telefone</th>
+                    <th>Status</th>
+                    <th width="280">Ações</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if (isset($advertisers) && !empty($advertisers)) : ?>
+                    <?php foreach ($advertisers as $advertiser) : ?>
+                        <tr>
+                            <td><?= $advertiser['name'] ?></td>
+                            <td><?= $advertiser['email'] ?></td>
+                            <td><?= $advertiser['document'] ?></td>
+                            <td><?= $advertiser['phone'] ?></td>
+                            <td>
+                                <span class="badge <?= $advertiser['status'] === 'ativo' ? 'bg-success' : 'bg-danger' ?>">
+                                    <?= ucfirst($advertiser['status']) ?>
+                                </span>
+                            </td>
+                            <td>
+                                <div class="btn-group" role="group">
+                                    <a href="/anunciantes/editar" class="btn btn-sm btn-primary" style="width: 80px">Editar</a>
+                                    <?php if ($advertiser['status'] === 'ativo') : ?>
+                                        <a href="/anunciantes/desativar" class="btn btn-sm btn-warning" style="width: 80px">Desativar</a>
+                                    <?php else : ?>
+                                        <a href="/anunciantes/ativar" class="btn btn-sm btn-success" style="width: 80px">Ativar</a>
+                                    <?php endif; ?>
+                                    <a href="/anunciantes/deletar" class="btn btn-sm btn-danger" style="width: 80px" 
+                                       onclick="return confirm('Tem certeza que deseja excluir este anunciante?')">
+                                        Excluir
+                                    </a>
+                                </div>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php else : ?>
+                    <tr>
+                        <td colspan="6" class="text-center">Nenhum anunciante cadastrado.</td>
+                    </tr>
+                <?php endif; ?>
+            </tbody>
+        </table>
+    </div>
+</section> 


### PR DESCRIPTION
fix #57 

- Cria estrutura completa do módulo de anunciantes:
  - Views para listagem, criação e edição
  - Rotas em português (/anunciantes/*)
  - Controller com dados temporários para teste
  - Enum Status (ACTIVE/INACTIVE)
  - Entidade Advertiser com atributos e métodos:
    * UUID, nome, email, documento, telefone, status e timestamps
    * Getters/setters e controle de status
    * Atualização automática de timestamps

Dependências:
- Adiciona ramsey/uuid para geração de UUIDs